### PR TITLE
rework tileEffects to include bumpHandlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 jspm_packages
 .serverless

--- a/client/src/tile-effects/brick.js
+++ b/client/src/tile-effects/brick.js
@@ -1,0 +1,3 @@
+export const brick = (playerSprite, tile) => {
+	tile.tilemap.removeTile(tile)
+}

--- a/client/src/tile-effects/index.js
+++ b/client/src/tile-effects/index.js
@@ -1,22 +1,65 @@
+/* for when these are added
+import { crumble } from './crumble'
+import { vanish } from './vanish'
+import { push } from './push'
+import { safetyNet } from './safetyNet'
+*/
+import { down } from './down'
+import { up } from './up'
 import { left } from './left'
 import { right } from './right'
-import { up } from './up'
-import { down } from './down'
 import { mine } from './mine'
 
+
+/* for when these are added
+import { item } from './item'
+import { finish } from './finish'
+import { rotateClockwise } from './rotateClockwise'
+import { rotateCounterclockwise } from './rotateCounterclockwise'
+import { infiniteItem } from './infiniteItem'
+import { happy } from './happy'
+import { sad } from './sad'
+import { heal } from './heal'
+import { time } from './time'
+*/
+import { brick } from './brick'
+
 const collideHandlers = {
-    up,
+    /*crumble,
+    vanish,
+    push,
+    safetyNet,*/
     down,
+    up,
     left,
     right,
     mine
 }
 
+const bumpHandlers = {
+    /*item,
+    finish,
+    rotateClockwise,
+    rotateCounterclockwise,
+    infiniteItem,
+    happy,
+    sad,
+    heal,
+    time,*/
+    brick
+}
+
 export function tileEffects (playerSprite, tile) {
+    let handlers = null
     if (tile.properties.collideHandlers) {
-        const collideHandlerNames = tile.properties.collideHandlers.split(',')
-        collideHandlerNames.forEach((handlerName) => {
-            const handler = collideHandlers[handlerName]
+        handlers = tile.properties.collideHandlers
+    } else if (tile.properties.bumpHandlers) {
+        handlers = tile.properties.bumpHandlers
+    }
+    if (handlers) {
+        const handlerNames = handlers.split(',')
+        handlerNames.forEach((handlerName) => {
+            const handler = handlers[handlerName]
             if (handler) {
                 handler(playerSprite, tile)
             }

--- a/client/src/tile-effects/index.js
+++ b/client/src/tile-effects/index.js
@@ -50,16 +50,18 @@ const bumpHandlers = {
 }
 
 export function tileEffects (playerSprite, tile) {
-    let handlers = null
     if (tile.properties.collideHandlers) {
-        handlers = tile.properties.collideHandlers
+        const collideHandlerNames = tile.properties.collideHandlers.split(',')
+        collideHandlerNames.forEach((handlerName) => {
+            const handler = collideHandlers[handlerName]
+            if (handler) {
+                handler(playerSprite, tile)
+            }
+        })
     } else if (tile.properties.bumpHandlers) {
-        handlers = tile.properties.bumpHandlers
-    }
-    if (handlers) {
-        const handlerNames = handlers.split(',')
-        handlerNames.forEach((handlerName) => {
-            const handler = handlers[handlerName]
+        const bumpHandlerNames = tile.properties.bumpHandlers.split(',')
+        bumpHandlerNames.forEach((handlerName) => {
+            const handler = bumpHandlers[handlerName]
             if (handler) {
                 handler(playerSprite, tile)
             }


### PR DESCRIPTION
I'm not sure if this is how you want to tackle this, but here's a start I suppose!

Full changes:
 - Let `tileEffects` serve as a universal function between `collideHandlers` and `bumpHandlers`
 - Add the pending additions to both `collideHandlers` and `bumpHandlers`
 - Add .DS_Store (mac config file) to .gitignore.

Known issue: touching any block while rotated is treated as a collide event. To fix this, there needs to be a separate check for detecting the direction of the collision. I didn't add this because my javascript knowledge is *very* limited.